### PR TITLE
Reestricciones correo y dni

### DIFF
--- a/PRACTICO_2_DOCUMENTACION/src/main/java/com/is1/proyecto/App.java
+++ b/PRACTICO_2_DOCUMENTACION/src/main/java/com/is1/proyecto/App.java
@@ -537,6 +537,11 @@ public class App {
                 return "";
             }
 
+            if (!dni.matches("\\d+")) {
+                res.redirect(redirectUrl + "?error=El+DNI+solo+debe+contener+numeros,+sin+puntos+ni+letras");
+                return "";
+            }
+
             try {
                 // VALIDACIÓN: Verificamos que la carrera exista en la BD
                 com.is1.proyecto.models.Carrera carreraExistente = com.is1.proyecto.models.Carrera
@@ -604,8 +609,13 @@ public class App {
                 return "";
             }
 
-            if (!correo.contains("@") || !correo.contains(".")) {
-                res.redirect(redirectUrl + "?error=El+formato+del+correo+electronico+no+es+valido");
+            if (!correo.toLowerCase().endsWith("@uni.edu")) {
+                res.redirect(redirectUrl + "?error=El+correo+electronico+institucional+debe+terminar+en+@uni.edu");
+                return "";
+            }
+
+            if (!dni.matches("\\d+")) {
+                res.redirect(redirectUrl + "?error=El+DNI+solo+debe+contener+numeros,+sin+puntos+ni+letras");
                 return "";
             }
 

--- a/PRACTICO_2_DOCUMENTACION/src/main/resources/templates/admin/alumno_form.mustache
+++ b/PRACTICO_2_DOCUMENTACION/src/main/resources/templates/admin/alumno_form.mustache
@@ -45,6 +45,9 @@
             <div>
                 <label for="dni" class="block text-gray-700 text-sm font-medium mb-1">DNI:</label>
                 <input type="text" id="dni" name="dni" required
+                       pattern="[0-9]+" 
+                       title="El DNI solo debe contener números, sin puntos, espacios ni letras."
+                       placeholder="Ej: 30123456"
                        class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
             </div>
 

--- a/PRACTICO_2_DOCUMENTACION/src/main/resources/templates/admin/profesor_form.mustache
+++ b/PRACTICO_2_DOCUMENTACION/src/main/resources/templates/admin/profesor_form.mustache
@@ -45,6 +45,9 @@
             <div>
                 <label for="dni" class="block text-gray-700 text-sm font-medium mb-1">DNI:</label>
                 <input type="text" id="dni" name="dni" required
+                       pattern="[0-9]+" 
+                       title="El DNI solo debe contener números, sin puntos, espacios ni letras."
+                       placeholder="Ej: 30123456"
                        class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
             </div>
 


### PR DESCRIPTION
- Modificación App.java
- Modificación alumno_form.mustache
- Modificación profesor_form.mustache

Se implemento que la reestricción de que el email del profesor tiene que terminar en "@uni.edu" y los dni no pueden llevar otro caracter que no sean números